### PR TITLE
refactor: move create offer on allowed negotiation

### DIFF
--- a/examples/conference/index.html
+++ b/examples/conference/index.html
@@ -157,14 +157,16 @@
             });
 
             peer.addEventListener('negotiationneeded', async () => {
-                const offer = await peer.createOffer();
-                await peer.setLocalDescription(offer);
-
                 const allowNegotiateResponse = await fetch(`${apiOrigin}/${apiVersion}/rooms/${roomId}/isallownegotiate/${clientId}`, {
                     method: 'POST',
                 });
 
                 if (allowNegotiateResponse.ok) {
+                    if (!peer) return;
+
+                    const offer = await peer.createOffer();
+                    await peer.setLocalDescription(offer);
+
                     const negotiateResponse = await fetch(`${apiOrigin}/${apiVersion}/rooms/${roomId}/negotiate/${clientId}`, {
                         method: 'PUT',
                         headers: {


### PR DESCRIPTION
# Description
This will refactor the logic by ensuring the process of creating offer and set local description only be run when the negotiation request is allowed.